### PR TITLE
feat: enable sub-tasks

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -92,7 +92,7 @@ impl<A: Actor> Context<A> {
 impl<A: Actor> Context<A> {
     /// Add a child actor.
     ///
-    /// This actor will be held until this actor is stopped.
+    /// This child actor is held until this context is stopped.
     pub fn add_child(&mut self, child: impl Into<Sender<()>>) {
         self.children
             .entry(TypeId::of::<()>())
@@ -100,9 +100,10 @@ impl<A: Actor> Context<A> {
             .push(Box::new(child.into()));
     }
 
-    /// Register a child actor.
+    /// Register a child actor by `Message` type.
     ///
-    /// This actor will be held until this actor is stopped.
+    /// This actor will be held until this actor is stopped via a `Sender`.
+    ///
     pub fn register_child<M: Message<Response = ()>>(&mut self, child: impl Into<Sender<M>>) {
         self.children
             .entry(TypeId::of::<M>())

--- a/src/context.rs
+++ b/src/context.rs
@@ -211,7 +211,10 @@ mod task_handling {
 
     /// Task Handling
     impl<A: Actor> Context<A> {
-        fn spawn_task(&mut self, task: impl Future<Output = ()> + Send + 'static) {
+        /// Spawn a task that will be executed in the background.
+        ///
+        /// The task will be aborted when the actor is stopped.
+        pub fn spawn_task(&mut self, task: impl Future<Output = ()> + Send + 'static) {
             let (task, handle) = futures::future::abortable(task);
 
             self.tasks.push(handle);


### PR DESCRIPTION
This pull request refines the `Context` struct in `src/context.rs` by improving documentation and modifying method visibility to enhance clarity and usability. The main changes involve updates to comments for better explanation of functionality and making the `spawn_task` method public for external use.

### Documentation improvements:
* Updated comments for `add_child` and `register_child` methods to clarify the behavior of child actors and their lifecycle in the context.

### API enhancements:
* Made the `spawn_task` method public, allowing external users to spawn background tasks within the actor's context. Added documentation to explain task lifecycle and behavior.