### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 
 description = "A small actor library"
 documentation = "https://docs.rs/hannibal/"
-homepage = "https://github.com/hoodie/hannibal"
+repository = "https://github.com/hoodie/hannibal"
 keywords = ["actor", "stream"]
 categories = ["asynchronous"]
 


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/104