### PR TITLE
fix: correctly handle finished streams

### DIFF
--- a/examples/signal-service.rs
+++ b/examples/signal-service.rs
@@ -28,8 +28,9 @@ impl StreamHandler<i32> for SignalService {
         }
     }
 
-    async fn finished(&mut self, _ctx: &mut Context<Self>) {
+    async fn finished(&mut self, ctx: &mut Context<Self>) {
         println!("Received {:?} signals", self.sig_count);
+        ctx.stop().unwrap();
     }
 }
 

--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -21,6 +21,9 @@ impl StreamHandler<i32> for FizzBuzzer {
             _ => {}
         }
     }
+    async fn finished(&mut self, ctx: &mut Context<Self>) {
+        ctx.stop().unwrap();
+    }
 }
 
 #[hannibal::main]

--- a/examples/streams_collector.rs
+++ b/examples/streams_collector.rs
@@ -7,6 +7,9 @@ impl<T: Send> StreamHandler<T> for Collector<T> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: T) {
         self.0.push(msg);
     }
+    async fn finished(&mut self, ctx: &mut Context<Self>) {
+        ctx.stop().unwrap();
+    }
 }
 
 #[hannibal::main]

--- a/hannibal-examples/Cargo.lock
+++ b/hannibal-examples/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hannibal"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-global-executor",
  "async-lock",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "hannibal-derive"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/hannibal-examples/src/axum-ws-actor.rs
+++ b/hannibal-examples/src/axum-ws-actor.rs
@@ -48,8 +48,9 @@ impl StreamHandler<WsStreamMessage> for WebsocketConnector {
         };
     }
 
-    async fn finished(&mut self, _ctx: &mut hannibal::Context<Self>) {
-        log::info!("websocket stream ended")
+    async fn finished(&mut self, ctx: &mut hannibal::Context<Self>) {
+        log::info!("websocket stream ended");
+        ctx.stop().unwrap();
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -30,6 +30,10 @@ pub trait Handler<M: Message>: Actor {
 ///             _ => {}
 ///         }
 ///     }
+///
+///     async fn finished(&mut self, ctx: &mut Context<Self>) {
+///         ctx.stop().unwrap();
+///     }
 /// }
 ///
 /// # #[hannibal::main]


### PR DESCRIPTION
BREAKING CHANGE: from now on StreamHandling Actors do not automatically stop when the stream is finished

If you want your Actor to stop when the attached stream is finished you need to call stop in the finished function:

```rs
impl StreamHandler<i32> for FizzBuzzer {
    async fn finished(&mut self, ctx: &mut Context<Self>) {
        ctx.stop().unwrap();
    }
}
```