### PR TITLE
fix: unable to publish<M> from actor unless actor is also Handler<M>

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -238,8 +238,6 @@ impl<A: Actor> Context<A> {
     /// Every actor can publish messages to the broker
     /// which will be delivered to all actors that subscribe to the message.
     pub async fn publish<M: crate::Message<Response = ()> + Clone>(&self, message: M) -> Result<()>
-    where
-        A: Handler<M>,
     {
         crate::Broker::publish(message).await
     }


### PR DESCRIPTION
Couldn't send message M to broker through `ctx.publish` unless actor was also `Handler<M>`. Didn't make sense to make the actor forced to handle the published message. 