### PR TITLE
chore: Add repository field to Cargo.toml

### DIFF
--- a/hannibal-derive/Cargo.toml
+++ b/hannibal-derive/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 description = "A small actor library"
 documentation = "https://docs.rs/hannibal/"
 homepage = "https://github.com/hoodie/hannibal"
+repository = "https://github.com/hoodie/hannibal"
 keywords = ["actor", "derive"]
 
 


### PR DESCRIPTION
It is better to use the `repository` field than just the `homepage` field as you do in most of your other crates.